### PR TITLE
Fix crash when trying to get the area of a polygon with less than 3 points

### DIFF
--- a/xmsgeom/geometry/geoms.cpp
+++ b/xmsgeom/geometry/geoms.cpp
@@ -1474,6 +1474,8 @@ bool gmInsideOrOnLineWithTol(const Pt3d* p1,
 //------------------------------------------------------------------------------
 double gmPolygonArea(const Pt3d* pts, size_t npoints)
 {
+  if (npoints < 3)
+    return 0.0;
   size_t id;
   double area = 0.0;
 


### PR DESCRIPTION
Fix crash when trying to get the area of a polygon with less than 3 points